### PR TITLE
Fix __init__.py.

### DIFF
--- a/freeenergyframework/__init__.py
+++ b/freeenergyframework/__init__.py
@@ -3,8 +3,6 @@ FreeEnergyFramework
 Report results for free energy simualtions
 """
 
-# Add imports here
-from .read import *
 
 # Handle versioneer
 from ._version import get_versions


### PR DESCRIPTION
## Description
There is an import of a submodule called `freeenergyframework.read`, which is not available. I have deleted the line.

## Status
- [ ] Ready to go